### PR TITLE
chore: make debug logging configurable

### DIFF
--- a/boundimports.go
+++ b/boundimports.go
@@ -7,7 +7,6 @@ package pe
 import (
 	"bytes"
 	"encoding/binary"
-	"log"
 )
 
 const (
@@ -100,7 +99,7 @@ func (pe *File) parseBoundImportDirectory(rva, size uint32) (err error) {
 		}
 
 		if section == nil {
-			log.Printf("RVA of IMAGE_BOUND_IMPORT_DESCRIPTOR points to an invalid address: 0x%x", rva)
+			DebugLogger.Printf("RVA of IMAGE_BOUND_IMPORT_DESCRIPTOR points to an invalid address: 0x%x", rva)
 			return nil
 		}
 

--- a/exception.go
+++ b/exception.go
@@ -6,7 +6,6 @@ package pe
 
 import (
 	"encoding/binary"
-	"log"
 	"strconv"
 )
 
@@ -408,7 +407,7 @@ func (pe *File) parseUnwindCode(offset uint32, version uint8) (UnwindCode, int) 
 
 	default:
 		advanceBy++ // so we can get out of the loop
-		log.Printf("Wrong unwind opcode %d", unwindCode.UnwindOp)
+		DebugLogger.Printf("Wrong unwind opcode %d", unwindCode.UnwindOp)
 	}
 
 	return unwindCode, advanceBy

--- a/exports.go
+++ b/exports.go
@@ -247,7 +247,7 @@ func (pe *File) parseExportDirectory(rva, size uint32) error {
 	}
 
 	if parsingFailed {
-		fmt.Printf("RVA AddressOfNames in the export directory points to an "+
+		DebugLogger.Printf("RVA AddressOfNames in the export directory points to an "+
 			"invalid address: 0x%x\n", exportDir.AddressOfNames)
 	}
 

--- a/file.go
+++ b/file.go
@@ -6,11 +6,11 @@ package pe
 
 import (
 	"errors"
-	"fmt"
 	"io"
+	"log"
 	"os"
 
-	mmap "github.com/edsrzf/mmap-go"
+	"github.com/edsrzf/mmap-go"
 )
 
 // A File represents an open PE file.
@@ -229,7 +229,7 @@ func (pe *File) ParseDataDirectories() error {
 				//  keep parsing data directories even though some entries fails.
 				defer func() {
 					if e := recover(); e != nil {
-						fmt.Printf("Unhandled Exception when trying to parse data directory %s, reason: %v\n",
+						DebugLogger.Printf("Unhandled Exception when trying to parse data directory %s, reason: %v\n",
 							pe.PrettyDataDirectory(entryIndex), e)
 						foundErr = true
 					}
@@ -237,7 +237,7 @@ func (pe *File) ParseDataDirectories() error {
 
 				err := funcMaps[entryIndex](va, size)
 				if err != nil {
-					fmt.Printf("Failed to parse data directory %s, reason: %v\n",
+					DebugLogger.Printf("Failed to parse data directory %s, reason: %v\n",
 						pe.PrettyDataDirectory(entryIndex), err)
 					foundErr = true
 				}
@@ -250,3 +250,5 @@ func (pe *File) ParseDataDirectories() error {
 	}
 	return nil
 }
+
+var DebugLogger *log.Logger = log.New(os.Stderr, "", log.Ldate | log.Ltime)

--- a/imports.go
+++ b/imports.go
@@ -272,7 +272,7 @@ func (pe *File) getImportTable32(rva uint32, maxLen uint32,
 		thunk := ImageThunkData32{}
 		err := pe.structUnpack(&thunk, offset, size)
 		if err != nil {
-			// log.Printf("Error parsing the import table. " +
+			// DebugLogger.Printf("Error parsing the import table. " +
 			// 	"Invalid data at RVA: 0x%x", rva)
 			return []*ThunkData32{}, nil
 		}
@@ -287,7 +287,7 @@ func (pe *File) getImportTable32(rva uint32, maxLen uint32,
 		// Seen in PE with SHA256:
 		// 5945bb6f0ac879ddf61b1c284f3b8d20c06b228e75ae4f571fa87f5b9512902c
 		if thunk.AddressOfData >= startRVA && thunk.AddressOfData <= rva {
-			log.Printf("Error parsing the import table. "+
+			DebugLogger.Printf("Error parsing the import table. "+
 				"AddressOfData overlaps with THUNK_DATA for THUNK at: "+
 				"RVA 0x%x", rva)
 			break
@@ -397,7 +397,7 @@ func (pe *File) getImportTable64(rva uint32, maxLen uint32,
 		thunk := ImageThunkData64{}
 		err := pe.structUnpack(&thunk, offset, size)
 		if err != nil {
-			// log.Printf("Error parsing the import table. " +
+			// DebugLogger.Printf("Error parsing the import table. " +
 			// 	"Invalid data at RVA: 0x%x", rva)
 			return []*ThunkData64{}, nil
 		}
@@ -413,7 +413,7 @@ func (pe *File) getImportTable64(rva uint32, maxLen uint32,
 		// 5945bb6f0ac879ddf61b1c284f3b8d20c06b228e75ae4f571fa87f5b9512902c
 		if thunk.AddressOfData >= uint64(startRVA) &&
 			thunk.AddressOfData <= uint64(rva) {
-			log.Printf("Error parsing the import table. "+
+			DebugLogger.Printf("Error parsing the import table. "+
 				"AddressOfData overlaps with THUNK_DATA for THUNK at: "+
 				"RVA 0x%x", rva)
 			break

--- a/resource.go
+++ b/resource.go
@@ -211,7 +211,7 @@ func (pe *File) doParseResourceDirectory(rva, size, baseRVA, level uint32,
 
 	// Set a hard limit on the maximum reasonable number of entries.
 	if numberOfEntries > maxAllowedEntries {
-		log.Printf(`Error parsing the resources directory. 
+		DebugLogger.Printf(`Error parsing the resources directory.
 		 The directory contains %d entries`, numberOfEntries)
 		return ResourceDirectory{}, nil
 	}


### PR DESCRIPTION
Instead of writing debug messages about encountered errors during
PE parsing to Stdout or the default log, write them to a dedicated
debug logger which can be adjusted by library users.