### PR TITLE
Remove pointers from main PE struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,29 @@
-# Portable Executable Parser [![GoDoc](http://godoc.org/github.com/saferwall/pe?status.svg)](https://pkg.go.dev/github.com/saferwall/pe) ![Go Version](https://img.shields.io/badge/go%20version-%3E=1.15-61CFDD.svg?style=flat-square) [![Report Card](https://goreportcard.com/badge/github.com/saferwall/pe)](https://goreportcard.com/report/github.com/saferwall/pe) [![codecov](https://codecov.io/gh/saferwall/pe/branch/main/graph/badge.svg?token=W7WTOUZLRY)](https://codecov.io/gh/saferwall/pe) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/saferwall/pe/Build%20&%20Test)
+# Portable Executable Parser
+
+[![GoDoc](http://godoc.org/github.com/saferwall/pe?status.svg)](https://pkg.go.dev/github.com/saferwall/pe) ![Go Version](https://img.shields.io/badge/go%20version-%3E=1.15-61CFDD.svg) [![Report Card](https://goreportcard.com/badge/github.com/saferwall/pe)](https://goreportcard.com/report/github.com/saferwall/pe) [![codecov](https://codecov.io/gh/saferwall/pe/branch/main/graph/badge.svg?token=W7WTOUZLRY)](https://codecov.io/gh/saferwall/pe) ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/saferwall/pe/Build%20&%20Test)
 
 **pe** is a go package for parsing the [portable executable](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format) file format. This package was designed with malware analysis in mind, and being resistent to PE malformations.
 
 ## Table of content
 
--   [Features](#features)
--   [Installing](#installing)
--   [Using the library](#using-the-library)
-    -   [Access the PE header](#pe-header)
-    -   [Viewing the rich header](#rich-header)
-    -   [Iterating over sections](#iterating-over-sections)
--   [Roadmap](#roadmap)
--   [Contributing](#contributing)
--   [License](#license)
--   [References](#references)
+- [Portable Executable Parser](#portable-executable-parser)
+  - [Table of content](#table-of-content)
+  - [Features](#features)
+  - [Installing](#installing)
+  - [Using the library](#using-the-library)
+    - [PE Header](#pe-header)
+    - [Rich Header](#rich-header)
+    - [Iterating over sections](#iterating-over-sections)
+  - [Roadmap](#roadmap)
+  - [Fuzz Testing](#fuzz-testing)
+  - [References](#references)
 
 ## Features
 
 -   Works with PE32/PE32+ file fomat.
 -   Supports Intel x86/AMD64/ARM7ARM7 Thumb/ARM8-64/IA64/CHPE architectures.
 -   MS DOS header.
--   Rich Header (calculate checksum).
+-   Rich Header (calculate checksum and hash).
 -   NT Header (file header + optional header).
 -   COFF symbol table and string table.
 -   Sections headers + entropy calculation.
@@ -80,15 +83,15 @@ Afterwards, a call to the `Parse()` method will give you access to all the diffe
 ```go
 type File struct {
 	DOSHeader    ImageDOSHeader
-	RichHeader   *RichHeader
+	RichHeader   RichHeader
 	NtHeader     ImageNtHeader
-	COFF         *COFF
+	COFF         COFF
 	Sections     []Section
 	Imports      []Import
-	Export       *Export
+	Export       Export
 	Debugs       []DebugEntry
 	Relocations  []Relocation
-	Resources    *ResourceDirectory
+	Resources    ResourceDirectory
 	TLS          *TLSDirectory
 	LoadConfig   *LoadConfig
 	Exceptions   []Exception

--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ type File struct {
 	Debugs       []DebugEntry
 	Relocations  []Relocation
 	Resources    ResourceDirectory
-	TLS          *TLSDirectory
-	LoadConfig   *LoadConfig
+	TLS          TLSDirectory
+	LoadConfig   LoadConfig
 	Exceptions   []Exception
-	Certificates *Certificate
+	Certificates Certificate
 	DelayImports []DelayImport
 	BoundImports []BoundImportDescriptorData
 	GlobalPtr    uint32
-	CLR          *CLRData
+	CLR          CLRData
 	IAT          []IATEntry
 	Header       []byte
 	data         mmap.MMap

--- a/cmd/pedumper.go
+++ b/cmd/pedumper.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Saferwall. All rights reserved.
+// Copyright 2022 Saferwall. All rights reserved.
 // Use of this source code is governed by Apache v2 license
 // license that can be found in the LICENSE file.
 

--- a/cmd/pedumper.go
+++ b/cmd/pedumper.go
@@ -104,13 +104,12 @@ func parsePE(filename string, cmd *cobra.Command) {
 		return
 	}
 
+	// Dump all results to disk in JSON format.
 	b, _ := json.Marshal(pe)
-
-	fmt.Print(prettyPrint(b))
-	return
+	os.WriteFile("out.json", []byte(prettyPrint(b)), 0644)
 
 	// Calculate the PE authentihash.
-	//pe.Authentihash()
+	pe.Authentihash()
 
 	// Calculate the PE checksum.
 	pe.Checksum()
@@ -197,6 +196,7 @@ func parsePE(filename string, cmd *cobra.Command) {
 		log.Info(prettyPrint(dosHeader))
 		log.Info(prettyPrint(ntHeader))
 		log.Info(prettyPrint(sectionsHeaders))
+		return
 	}
 
 	fmt.Println()

--- a/cmd/pedumper.go
+++ b/cmd/pedumper.go
@@ -104,6 +104,11 @@ func parsePE(filename string, cmd *cobra.Command) {
 		return
 	}
 
+	b, _ := json.Marshal(pe)
+
+	fmt.Print(prettyPrint(b))
+	return
+
 	// Calculate the PE authentihash.
 	//pe.Authentihash()
 
@@ -171,7 +176,7 @@ func parsePE(filename string, cmd *cobra.Command) {
 	}
 
 	wantCLR, _ := cmd.Flags().GetBool("clr")
-	if wantCLR && pe.CLR != nil {
+	if wantCLR {
 		dotnetMetadata, _ := json.Marshal(pe.CLR)
 		log.Info(prettyPrint(dotnetMetadata))
 		if modTable, ok := pe.CLR.MetadataTables[peparser.Module]; ok {

--- a/cmd/pedumper.go
+++ b/cmd/pedumper.go
@@ -106,7 +106,12 @@ func parsePE(filename string, cmd *cobra.Command) {
 
 	// Dump all results to disk in JSON format.
 	b, _ := json.Marshal(pe)
-	os.WriteFile("out.json", []byte(prettyPrint(b)), 0644)
+	f, err := os.Create("out.json")
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	f.WriteString(prettyPrint(b))
 
 	// Calculate the PE authentihash.
 	pe.Authentihash()

--- a/exports.go
+++ b/exports.go
@@ -312,19 +312,18 @@ func (pe *File) parseExportDirectory(rva, size uint32) error {
 		exp.Functions = append(exp.Functions, newExport)
 	}
 
-	pe.Export = &exp
+	pe.Export = exp
 	pe.HasExport = true
 	return nil
 }
 
 // GetExportFunctionByRVA return an export function given an RVA.
 func (pe *File) GetExportFunctionByRVA(rva uint32) ExportFunction {
-	if pe.Export != nil {
-		for _, exp := range pe.Export.Functions {
-			if exp.FunctionRVA == rva {
-				return exp
-			}
+	for _, exp := range pe.Export.Functions {
+		if exp.FunctionRVA == rva {
+			return exp
 		}
 	}
+
 	return ExportFunction{}
 }

--- a/file.go
+++ b/file.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Saferwall. All rights reserved.
+// Copyright 2022 Saferwall. All rights reserved.
 // Use of this source code is governed by Apache v2 license
 // license that can be found in the LICENSE file.
 
@@ -15,23 +15,23 @@ import (
 // A File represents an open PE file.
 type File struct {
 	DOSHeader    ImageDOSHeader              `json:",omitempty"`
-	RichHeader   *RichHeader                 `json:",omitempty"`
+	RichHeader   RichHeader                  `json:",omitempty"`
 	NtHeader     ImageNtHeader               `json:",omitempty"`
-	COFF         *COFF                       `json:",omitempty"`
+	COFF         COFF                        `json:",omitempty"`
 	Sections     []Section                   `json:",omitempty"`
 	Imports      []Import                    `json:",omitempty"`
-	Export       *Export                     `json:",omitempty"`
+	Export       Export                      `json:",omitempty"`
 	Debugs       []DebugEntry                `json:",omitempty"`
 	Relocations  []Relocation                `json:",omitempty"`
-	Resources    *ResourceDirectory          `json:",omitempty"`
-	TLS          *TLSDirectory               `json:",omitempty"`
-	LoadConfig   *LoadConfig                 `json:",omitempty"`
+	Resources    ResourceDirectory           `json:",omitempty"`
+	TLS          TLSDirectory                `json:",omitempty"`
+	LoadConfig   LoadConfig                  `json:",omitempty"`
 	Exceptions   []Exception                 `json:",omitempty"`
-	Certificates *Certificate                `json:",omitempty"`
+	Certificates Certificate                 `json:",omitempty"`
 	DelayImports []DelayImport               `json:",omitempty"`
 	BoundImports []BoundImportDescriptorData `json:",omitempty"`
 	GlobalPtr    uint32                      `json:",omitempty"`
-	CLR          *CLRData                    `json:",omitempty"`
+	CLR          CLRData                     `json:",omitempty"`
 	IAT          []IATEntry                  `json:",omitempty"`
 	Header       []byte
 	data         mmap.MMap

--- a/loadconfig.go
+++ b/loadconfig.go
@@ -1624,37 +1624,35 @@ func (pe *File) parseLoadConfigDirectory(rva, size uint32) error {
 	}
 
 	// Save the load config struct.
-	loadConfig := LoadConfig{}
-	pe.LoadConfig = &loadConfig
 	pe.HasLoadCFG = true
-	loadConfig.LoadCfgStruct = loadCfg
+	pe.LoadConfig.LoadCfgStruct = loadCfg
 
 	// Retrieve SEH handlers if there are any..
 	if pe.Is32 {
 		handlers := pe.getSEHHandlers()
-		loadConfig.SEH = handlers
+		pe.LoadConfig.SEH = handlers
 	}
 
 	// Retrieve Control Flow Guard Function Targets if there are any.
-	loadConfig.GFIDS = pe.getControlFlowGuardFunctions()
+	pe.LoadConfig.GFIDS = pe.getControlFlowGuardFunctions()
 
 	// Retrieve Control Flow Guard IAT entries if there are any.
-	loadConfig.CFGIAT = pe.getControlFlowGuardIAT()
+	pe.LoadConfig.CFGIAT = pe.getControlFlowGuardIAT()
 
 	// Retrive Long jump target functions if there are any.
-	loadConfig.CFGLongJump = pe.getLongJumpTargetTable()
+	pe.LoadConfig.CFGLongJump = pe.getLongJumpTargetTable()
 
 	// Retrieve compiled hybrid PE metadata if there are any.
-	loadConfig.CHPE = pe.getHybridPE()
+	pe.LoadConfig.CHPE = pe.getHybridPE()
 
 	// Retrieve dynamic value relocation table if there are any.
-	loadConfig.DVRT = pe.getDynamicValueRelocTable()
+	pe.LoadConfig.DVRT = pe.getDynamicValueRelocTable()
 
 	// Retrieve enclave configuration if there are any.
-	loadConfig.Enclave = pe.getEnclaveConfiguration()
+	pe.LoadConfig.Enclave = pe.getEnclaveConfiguration()
 
 	// Retrieve volatile metadat table if there are any.
-	loadConfig.VolatileMetadata = pe.getVolatileMetadata()
+	pe.LoadConfig.VolatileMetadata = pe.getVolatileMetadata()
 
 	return nil
 }

--- a/resource.go
+++ b/resource.go
@@ -305,7 +305,7 @@ func (pe *File) parseResourceDirectory(rva, size uint32) error {
 		return err
 	}
 
-	pe.Resources = &Resources
+	pe.Resources = Resources
 	pe.HasResource = true
 	return err
 }

--- a/richheader.go
+++ b/richheader.go
@@ -151,14 +151,14 @@ func (pe *File) ParseRichHeader() error {
 		rh.CompIDs = append(rh.CompIDs, cid)
 	}
 
-	pe.RichHeader = &rh
+	pe.RichHeader = rh
+	pe.HasRichHdr = true
 
 	checksum := pe.RichHeaderChecksum()
 	if checksum != rh.XorKey {
 		pe.Anomalies = append(pe.Anomalies, "Invalid rich header checksum")
 	}
 
-	pe.HasRichHdr = true
 	return nil
 }
 
@@ -193,9 +193,10 @@ func (pe *File) RichHeaderChecksum() uint32 {
 
 // RichHeaderHash calculate the Rich Header hash.
 func (pe *File) RichHeaderHash() string {
-	if pe.RichHeader == nil {
+	if !pe.HasRichHdr {
 		return ""
 	}
+
 	richIndex := bytes.Index(pe.RichHeader.Raw, []byte(RichSignature))
 	if richIndex == -1 {
 		return ""

--- a/richheader_test.go
+++ b/richheader_test.go
@@ -114,7 +114,7 @@ func TestParseRichHeader(t *testing.T) {
 			}
 
 			richheader := file.RichHeader
-			if !reflect.DeepEqual(richheader, &tt.out.richheader) {
+			if !reflect.DeepEqual(richheader, tt.out.richheader) {
 				t.Errorf("rich header test failed, got %v, want %v",
 					richheader, tt.out)
 			}

--- a/security.go
+++ b/security.go
@@ -291,7 +291,7 @@ func (pe *File) parseSecurityDirectory(rva, size uint32) error {
 		certContent = pe.data[fileOffset+certSize : fileOffset+certHeader.Length]
 		pkcs, err = pkcs7.Parse(certContent)
 		if err != nil {
-			pe.Certificates = &Certificate{Header: certHeader, Raw: certContent}
+			pe.Certificates = Certificate{Header: certHeader, Raw: certContent}
 			pe.HasSecurity = true
 			return err
 		}
@@ -382,7 +382,7 @@ func (pe *File) parseSecurityDirectory(rva, size uint32) error {
 		fileOffset = nextOffset
 	}
 
-	pe.Certificates = &Certificate{Header: certHeader, Content: pkcs,
+	pe.Certificates = Certificate{Header: certHeader, Content: pkcs,
 		Raw: certContent, Info: certInfo, Verified: isValid}
 	pe.HasSecurity = true
 	return nil

--- a/symbol.go
+++ b/symbol.go
@@ -310,13 +310,12 @@ func (pe *File) ParseCOFFSymbolTable() error {
 		offset += size
 	}
 
-	pe.COFF = &COFF{}
 	pe.COFF.SymbolTable = symbols
-	pe.HasCOFF = true
 
 	// Get the COFF string table.
 	pe.COFFStringTable()
 
+	pe.HasCOFF = true
 	return nil
 }
 

--- a/symbol_test.go
+++ b/symbol_test.go
@@ -95,7 +95,8 @@ func TestParseCOFFSymbolTable(t *testing.T) {
 				)
 			}
 
-			if file.COFF == nil {
+			// exit early when err is errCOFFSymbolsTooHigh.
+			if err == errCOFFSymbolsTooHigh {
 				return
 			}
 

--- a/tls.go
+++ b/tls.go
@@ -150,7 +150,7 @@ func (pe *File) parseTLSDirectory(rva, size uint32) error {
 		}
 	}
 
-	pe.TLS = &tls
+	pe.TLS = tls
 	pe.HasTLS = true
 	return nil
 }


### PR DESCRIPTION
The `File` structure has many pointer to struct fields. The reason why I put those fields as pointers is not to save some memory or because I needed the structs to be modified by some method, it was only yo make it easier when JSON marshaling so we can omit the empty structs because they contain NULL value.

This PR get rid of those pointers as the library should not be biased to any specific use case.

This should not break the APIs.