### PR TITLE
fix: resource entry names are cut off

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -230,7 +230,7 @@ func (pe *File) doParseResourceDirectory(rva, size, baseRVA, level uint32,
 				break
 			}
 			entryName = pe.readUnicodeStringAtRVA(baseRVA+nameOffset+2,
-				uint32(maxLen))
+				uint32(maxLen*2))
 		}
 
 		// A directory entry points to either another resource directory or to


### PR DESCRIPTION
The utf16 strings used for resource directory entries are prefixed with
their length in *characters* not bytes.