### PR TITLE
feat: PE Dumper to print PE headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Improve PE dumper to print PE headers [#61](https://github.com/saferwall/pe/pull/61).
+- Add `SerialNumber`, `SignatureAlgorithm` and `PubKeyAlgorithm` to the `CertInfo` [#60](https://github.com/saferwall/pe/pull/60).
+- Option to disable certificate validation [#59](https://github.com/saferwall/pe/pull/59).
+- Improve PE dumper to print exceptions [#57](https://github.com/saferwall/pe/pull/57).
 - Unit tests test debug directory [#49](https://github.com/saferwall/pe/pull/49).
 
 ### Fixed

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -249,6 +249,12 @@ func parsePE(filename string, cfg config) {
 			fmt.Fprintf(w, "Size Of Heap Commit:\t 0x%x (%s)\n", oh.SizeOfHeapCommit, BytesSize(float64(oh.SizeOfHeapCommit)))
 			fmt.Fprintf(w, "Loader Flags:\t 0x%x\n", oh.LoaderFlags)
 			fmt.Fprintf(w, "Number Of RVA And Sizes:\t 0x%x\n", oh.NumberOfRvaAndSizes)
+			fmt.Fprintf(w, "\n")
+			for entry := peparser.ImageDirectoryEntry(0); entry < peparser.ImageNumberOfDirectoryEntries; entry++ {
+				rva := oh.DataDirectory[entry].VirtualAddress
+				size := oh.DataDirectory[entry].Size
+				fmt.Fprintf(w, "%s Table:\t RVA: 0x%0.8x\t Size:0x%0.8x\t\n", entry.String(), rva, size)
+			}
 		} else {
 			oh := pe.NtHeader.OptionalHeader.(peparser.ImageOptionalHeader32)
 			dllCharacteristics := strings.Join(pe.PrettyDllCharacteristics(), " | ")
@@ -285,9 +291,15 @@ func parsePE(filename string, cfg config) {
 			fmt.Fprintf(w, "Size Of Heap Commit:\t 0x%x (%s)\n", oh.SizeOfHeapCommit, BytesSize(float64(oh.SizeOfHeapCommit)))
 			fmt.Fprintf(w, "Loader Flags:\t 0x%x\n", oh.LoaderFlags)
 			fmt.Fprintf(w, "Number Of RVA And Sizes:\t 0x%x\n", oh.NumberOfRvaAndSizes)
+			fmt.Fprintf(w, "\n")
+			for entry := peparser.ImageDirectoryEntry(0); entry < peparser.ImageNumberOfDirectoryEntries; entry++ {
+				rva := oh.DataDirectory[entry].VirtualAddress
+				size := oh.DataDirectory[entry].Size
+				fmt.Fprintf(w, "%s Table:\t RVA: 0x%0.8x\t Size:0x%0.8x\t\n", entry.String(), rva, size)
+			}
 		}
-
 		w.Flush()
+
 	}
 
 	if cfg.wantSections {

--- a/cmd/size.go
+++ b/cmd/size.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// See: http://en.wikipedia.org/wiki/Binary_prefix
+const (
+	// Decimal
+
+	KB = 1024
+	MB = 1000 * KB
+	GB = 1000 * MB
+	TB = 1000 * GB
+	PB = 1000 * TB
+
+	// Binary
+
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+	TiB = 1024 * GiB
+	PiB = 1024 * TiB
+)
+
+type unitMap map[byte]int64
+
+var (
+	decimalMap = unitMap{'k': KB, 'm': MB, 'g': GB, 't': TB, 'p': PB}
+	binaryMap  = unitMap{'k': KiB, 'm': MiB, 'g': GiB, 't': TiB, 'p': PiB}
+)
+
+var (
+	decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
+	binaryAbbrs  = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+)
+
+func getSizeAndUnit(size float64, base float64, _map []string) (float64, string) {
+	i := 0
+	unitsLimit := len(_map) - 1
+	for size >= base && i < unitsLimit {
+		size = size / base
+		i++
+	}
+	return size, _map[i]
+}
+
+// CustomSize returns a human-readable approximation of a size
+// using custom format.
+func CustomSize(format string, size float64, base float64, _map []string) string {
+	size, unit := getSizeAndUnit(size, base, _map)
+	return fmt.Sprintf(format, size, unit)
+}
+
+// HumanSizeWithPrecision allows the size to be in any precision,
+// instead of 4 digit precision used in units.HumanSize.
+func HumanSizeWithPrecision(size float64, precision int) string {
+	size, unit := getSizeAndUnit(size, 1000.0, decimapAbbrs)
+	return fmt.Sprintf("%.*g%s", precision, size, unit)
+}
+
+// HumanSize returns a human-readable approximation of a size
+// capped at 4 valid numbers (eg. "2.746 MB", "796 KB").
+func HumanSize(size float64) string {
+	return HumanSizeWithPrecision(size, 4)
+}
+
+// BytesSize returns a human-readable size in bytes, kibibytes,
+// mebibytes, gibibytes, or tebibytes (eg. "44kiB", "17MiB").
+func BytesSize(size float64) string {
+	return CustomSize("%.4g%s", size, 1024.0, binaryAbbrs)
+}
+
+// FromHumanSize returns an integer from a human-readable specification of a
+// size using SI standard (eg. "44kB", "17MB").
+func FromHumanSize(size string) (int64, error) {
+	return parseSize(size, decimalMap)
+}
+
+// RAMInBytes parses a human-readable string representing an amount of RAM
+// in bytes, kibibytes, mebibytes, gibibytes, or tebibytes and
+// returns the number of bytes, or -1 if the string is unparseable.
+// Units are case-insensitive, and the 'b' suffix is optional.
+func RAMInBytes(size string) (int64, error) {
+	return parseSize(size, binaryMap)
+}
+
+// Parses the human-readable size string into the amount it represents.
+func parseSize(sizeStr string, uMap unitMap) (int64, error) {
+	// TODO: rewrite to use strings.Cut if there's a space
+	// once Go < 1.18 is deprecated.
+	sep := strings.LastIndexAny(sizeStr, "01234567890. ")
+	if sep == -1 {
+		// There should be at least a digit.
+		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
+	}
+	var num, sfx string
+	if sizeStr[sep] != ' ' {
+		num = sizeStr[:sep+1]
+		sfx = sizeStr[sep+1:]
+	} else {
+		// Omit the space separator.
+		num = sizeStr[:sep]
+		sfx = sizeStr[sep+1:]
+	}
+
+	size, err := strconv.ParseFloat(num, 64)
+	if err != nil {
+		return -1, err
+	}
+	// Backward compatibility: reject negative sizes.
+	if size < 0 {
+		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
+	}
+
+	if len(sfx) == 0 {
+		return int64(size), nil
+	}
+
+	// Process the suffix.
+
+	if len(sfx) > 3 { // Too long.
+		goto badSuffix
+	}
+	sfx = strings.ToLower(sfx)
+	// Trivial case: b suffix.
+	if sfx[0] == 'b' {
+		if len(sfx) > 1 { // no extra characters allowed after b.
+			goto badSuffix
+		}
+		return int64(size), nil
+	}
+	// A suffix from the map.
+	if mul, ok := uMap[sfx[0]]; ok {
+		size *= float64(mul)
+	} else {
+		goto badSuffix
+	}
+
+	// The suffix may have extra "b" or "ib" (e.g. KiB or MB).
+	switch {
+	case len(sfx) == 2 && sfx[1] != 'b':
+		goto badSuffix
+	case len(sfx) == 3 && sfx[1:] != "ib":
+		goto badSuffix
+	}
+
+	return int64(size), nil
+
+badSuffix:
+	return -1, fmt.Errorf("invalid suffix: '%s'", sfx)
+}

--- a/cmd/size.go
+++ b/cmd/size.go
@@ -10,7 +10,7 @@ import (
 const (
 	// Decimal
 
-	KB = 1024
+	KB = 1000
 	MB = 1000 * KB
 	GB = 1000 * MB
 	TB = 1000 * GB

--- a/cmd/size_test.go
+++ b/cmd/size_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func ExampleBytesSize() {
+	fmt.Println(BytesSize(1024))
+	fmt.Println(BytesSize(1024 * 1024))
+	fmt.Println(BytesSize(1048576))
+	fmt.Println(BytesSize(2 * MiB))
+	fmt.Println(BytesSize(3.42 * GiB))
+	fmt.Println(BytesSize(5.372 * TiB))
+	fmt.Println(BytesSize(2.22 * PiB))
+}
+
+func ExampleHumanSize() {
+	fmt.Println(HumanSize(1000))
+	fmt.Println(HumanSize(1024))
+	fmt.Println(HumanSize(1000000))
+	fmt.Println(HumanSize(1048576))
+	fmt.Println(HumanSize(2 * MB))
+	fmt.Println(HumanSize(float64(3.42 * GB)))
+	fmt.Println(HumanSize(float64(5.372 * TB)))
+	fmt.Println(HumanSize(float64(2.22 * PB)))
+}
+
+func ExampleFromHumanSize() {
+	fmt.Println(FromHumanSize("32"))
+	fmt.Println(FromHumanSize("32b"))
+	fmt.Println(FromHumanSize("32B"))
+	fmt.Println(FromHumanSize("32k"))
+	fmt.Println(FromHumanSize("32K"))
+	fmt.Println(FromHumanSize("32kb"))
+	fmt.Println(FromHumanSize("32Kb"))
+	fmt.Println(FromHumanSize("32Mb"))
+	fmt.Println(FromHumanSize("32Gb"))
+	fmt.Println(FromHumanSize("32Tb"))
+	fmt.Println(FromHumanSize("32Pb"))
+}
+
+func ExampleRAMInBytes() {
+	fmt.Println(RAMInBytes("32"))
+	fmt.Println(RAMInBytes("32b"))
+	fmt.Println(RAMInBytes("32B"))
+	fmt.Println(RAMInBytes("32k"))
+	fmt.Println(RAMInBytes("32K"))
+	fmt.Println(RAMInBytes("32kb"))
+	fmt.Println(RAMInBytes("32Kb"))
+	fmt.Println(RAMInBytes("32Mb"))
+	fmt.Println(RAMInBytes("32Gb"))
+	fmt.Println(RAMInBytes("32Tb"))
+	fmt.Println(RAMInBytes("32Pb"))
+	fmt.Println(RAMInBytes("32PB"))
+	fmt.Println(RAMInBytes("32P"))
+}
+
+func TestBytesSize(t *testing.T) {
+	assertEquals(t, "1KiB", BytesSize(1024))
+	assertEquals(t, "1MiB", BytesSize(1024*1024))
+	assertEquals(t, "1MiB", BytesSize(1048576))
+	assertEquals(t, "2MiB", BytesSize(2*MiB))
+	assertEquals(t, "3.42GiB", BytesSize(3.42*GiB))
+	assertEquals(t, "5.372TiB", BytesSize(5.372*TiB))
+	assertEquals(t, "2.22PiB", BytesSize(2.22*PiB))
+	assertEquals(t, "1.049e+06YiB", BytesSize(KiB*KiB*KiB*KiB*KiB*PiB))
+}
+
+func TestHumanSize(t *testing.T) {
+	assertEquals(t, "1kB", HumanSize(1000))
+	assertEquals(t, "1.024kB", HumanSize(1024))
+	assertEquals(t, "1MB", HumanSize(1000000))
+	assertEquals(t, "1.049MB", HumanSize(1048576))
+	assertEquals(t, "2MB", HumanSize(2*MB))
+	assertEquals(t, "3.42GB", HumanSize(float64(3.42*GB)))
+	assertEquals(t, "5.372TB", HumanSize(float64(5.372*TB)))
+	assertEquals(t, "2.22PB", HumanSize(float64(2.22*PB)))
+	assertEquals(t, "1e+04YB", HumanSize(float64(10000000000000*PB)))
+}
+
+func TestFromHumanSize(t *testing.T) {
+	assertSuccessEquals(t, 0, FromHumanSize, "0")
+	assertSuccessEquals(t, 0, FromHumanSize, "0b")
+	assertSuccessEquals(t, 0, FromHumanSize, "0B")
+	assertSuccessEquals(t, 0, FromHumanSize, "0 B")
+	assertSuccessEquals(t, 32, FromHumanSize, "32")
+	assertSuccessEquals(t, 32, FromHumanSize, "32b")
+	assertSuccessEquals(t, 32, FromHumanSize, "32B")
+	assertSuccessEquals(t, 32*KB, FromHumanSize, "32k")
+	assertSuccessEquals(t, 32*KB, FromHumanSize, "32K")
+	assertSuccessEquals(t, 32*KB, FromHumanSize, "32kb")
+	assertSuccessEquals(t, 32*KB, FromHumanSize, "32Kb")
+	assertSuccessEquals(t, 32*MB, FromHumanSize, "32Mb")
+	assertSuccessEquals(t, 32*GB, FromHumanSize, "32Gb")
+	assertSuccessEquals(t, 32*TB, FromHumanSize, "32Tb")
+	assertSuccessEquals(t, 32*PB, FromHumanSize, "32Pb")
+
+	assertSuccessEquals(t, 32.5*KB, FromHumanSize, "32.5kB")
+	assertSuccessEquals(t, 32.5*KB, FromHumanSize, "32.5 kB")
+	assertSuccessEquals(t, 32, FromHumanSize, "32.5 B")
+	assertSuccessEquals(t, 300, FromHumanSize, "0.3 K")
+	assertSuccessEquals(t, 300, FromHumanSize, ".3kB")
+
+	assertSuccessEquals(t, 0, FromHumanSize, "0.")
+	assertSuccessEquals(t, 0, FromHumanSize, "0. ")
+	assertSuccessEquals(t, 0, FromHumanSize, "0.b")
+	assertSuccessEquals(t, 0, FromHumanSize, "0.B")
+	assertSuccessEquals(t, 0, FromHumanSize, "-0")
+	assertSuccessEquals(t, 0, FromHumanSize, "-0b")
+	assertSuccessEquals(t, 0, FromHumanSize, "-0B")
+	assertSuccessEquals(t, 0, FromHumanSize, "-0 b")
+	assertSuccessEquals(t, 0, FromHumanSize, "-0 B")
+	assertSuccessEquals(t, 32, FromHumanSize, "32.")
+	assertSuccessEquals(t, 32, FromHumanSize, "32.b")
+	assertSuccessEquals(t, 32, FromHumanSize, "32.B")
+	assertSuccessEquals(t, 32, FromHumanSize, "32. b")
+	assertSuccessEquals(t, 32, FromHumanSize, "32. B")
+
+	// We do not tolerate extra leading or trailing spaces
+	// (except for a space after the number and a missing suffix).
+	assertSuccessEquals(t, 0, FromHumanSize, "0 ")
+
+	assertError(t, FromHumanSize, " 0")
+	assertError(t, FromHumanSize, " 0b")
+	assertError(t, FromHumanSize, " 0B")
+	assertError(t, FromHumanSize, " 0 B")
+	assertError(t, FromHumanSize, "0b ")
+	assertError(t, FromHumanSize, "0B ")
+	assertError(t, FromHumanSize, "0 B ")
+
+	assertError(t, FromHumanSize, "")
+	assertError(t, FromHumanSize, "hello")
+	assertError(t, FromHumanSize, ".")
+	assertError(t, FromHumanSize, ". ")
+	assertError(t, FromHumanSize, " ")
+	assertError(t, FromHumanSize, "  ")
+	assertError(t, FromHumanSize, " .")
+	assertError(t, FromHumanSize, " . ")
+	assertError(t, FromHumanSize, "-32")
+	assertError(t, FromHumanSize, "-32b")
+	assertError(t, FromHumanSize, "-32B")
+	assertError(t, FromHumanSize, "-32 b")
+	assertError(t, FromHumanSize, "-32 B")
+	assertError(t, FromHumanSize, "32b.")
+	assertError(t, FromHumanSize, "32B.")
+	assertError(t, FromHumanSize, "32 b.")
+	assertError(t, FromHumanSize, "32 B.")
+	assertError(t, FromHumanSize, "32 bb")
+	assertError(t, FromHumanSize, "32 BB")
+	assertError(t, FromHumanSize, "32 b b")
+	assertError(t, FromHumanSize, "32 B B")
+	assertError(t, FromHumanSize, "32  b")
+	assertError(t, FromHumanSize, "32  B")
+	assertError(t, FromHumanSize, " 32 ")
+	assertError(t, FromHumanSize, "32m b")
+	assertError(t, FromHumanSize, "32bm")
+}
+
+func TestRAMInBytes(t *testing.T) {
+	assertSuccessEquals(t, 32, RAMInBytes, "32")
+	assertSuccessEquals(t, 32, RAMInBytes, "32b")
+	assertSuccessEquals(t, 32, RAMInBytes, "32B")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32k")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32K")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32kb")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32Kb")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32Kib")
+	assertSuccessEquals(t, 32*KiB, RAMInBytes, "32KIB")
+	assertSuccessEquals(t, 32*MiB, RAMInBytes, "32Mb")
+	assertSuccessEquals(t, 32*GiB, RAMInBytes, "32Gb")
+	assertSuccessEquals(t, 32*TiB, RAMInBytes, "32Tb")
+	assertSuccessEquals(t, 32*PiB, RAMInBytes, "32Pb")
+	assertSuccessEquals(t, 32*PiB, RAMInBytes, "32PB")
+	assertSuccessEquals(t, 32*PiB, RAMInBytes, "32P")
+
+	assertSuccessEquals(t, 32, RAMInBytes, "32.3")
+	tmp := 32.3 * MiB
+	assertSuccessEquals(t, int64(tmp), RAMInBytes, "32.3 mb")
+	tmp = 0.3 * MiB
+	assertSuccessEquals(t, int64(tmp), RAMInBytes, "0.3MB")
+
+	assertError(t, RAMInBytes, "")
+	assertError(t, RAMInBytes, "hello")
+	assertError(t, RAMInBytes, "-32")
+	assertError(t, RAMInBytes, " 32 ")
+	assertError(t, RAMInBytes, "32m b")
+	assertError(t, RAMInBytes, "32bm")
+}
+
+func BenchmarkParseSize(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, s := range []string{
+			"", "32", "32b", "32 B", "32k", "32.5 K", "32kb", "32 Kb",
+			"32.8Mb", "32.9Gb", "32.777Tb", "32Pb", "0.3Mb", "-1",
+		} {
+			FromHumanSize(s)
+			RAMInBytes(s)
+		}
+	}
+}
+
+func assertEquals(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	if expected != actual {
+		t.Errorf("Expected '%v' but got '%v'", expected, actual)
+	}
+}
+
+// func that maps to the parse function signatures as testing abstraction
+type parseFn func(string) (int64, error)
+
+// Define 'String()' for pretty-print
+func (fn parseFn) String() string {
+	fnName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	return fnName[strings.LastIndex(fnName, ".")+1:]
+}
+
+func assertSuccessEquals(t *testing.T, expected int64, fn parseFn, arg string) {
+	t.Helper()
+	res, err := fn(arg)
+	if err != nil || res != expected {
+		t.Errorf("%s(\"%s\") -> expected '%d' but got '%d' with error '%v'", fn, arg, expected, res, err)
+	}
+}
+
+func assertError(t *testing.T, fn parseFn, arg string) {
+	t.Helper()
+	res, err := fn(arg)
+	if err == nil && res != -1 {
+		t.Errorf("%s(\"%s\") -> expected error but got '%d'", fn, arg, res)
+	}
+}

--- a/file.go
+++ b/file.go
@@ -201,7 +201,7 @@ func (pe *File) Parse() error {
 	return pe.ParseDataDirectories()
 }
 
-// stringify the data directory entry.
+// String stringify the data directory entry.
 func (entry ImageDirectoryEntry) String() string {
 	dataDirMap := map[ImageDirectoryEntry]string{
 		ImageDirectoryEntryExport:       "Export",

--- a/pe.go
+++ b/pe.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Saferwall. All rights reserved.
+// Copyright 2018 Saferwall. All rights reserved.
 // Use of this source code is governed by Apache v2 license
 // license that can be found in the LICENSE file.
 

--- a/pe.go
+++ b/pe.go
@@ -182,22 +182,22 @@ type ImageDirectoryEntry int
 // DataDirectory entries of an OptionalHeader
 const (
 	ImageDirectoryEntryExport       ImageDirectoryEntry = iota // Export Table
-	ImageDirectoryEntryImport                           = 1    // Import Table
-	ImageDirectoryEntryResource                         = 2    // Resource Table
-	ImageDirectoryEntryException                        = 3    // Exception Table
-	ImageDirectoryEntryCertificate                      = 4    // Certificate Directory
-	ImageDirectoryEntryBaseReloc                        = 5    // Base Relocation Table
-	ImageDirectoryEntryDebug                            = 6    // Debug
-	ImageDirectoryEntryArchitecture                     = 7    // Architecture Specific Data
-	ImageDirectoryEntryGlobalPtr                        = 8    // The RVA of the value to be stored in the global pointer register.
-	ImageDirectoryEntryTLS                              = 9    // The thread local storage (TLS) table
-	ImageDirectoryEntryLoadConfig                       = 10   // The load configuration table
-	ImageDirectoryEntryBoundImport                      = 11   // The bound import table
-	ImageDirectoryEntryIAT                              = 12   // Import Address Table
-	ImageDirectoryEntryDelayImport                      = 13   // Delay Import Descriptor
-	ImageDirectoryEntryCLR                              = 14   // CLR Runtime Header
-	ImageDirectoryEntryReserved                         = 15   // Must be zero
-	ImageNumberOfDirectoryEntries                       = 16   // Tables count.
+	ImageDirectoryEntryImport                                  // Import Table
+	ImageDirectoryEntryResource                                // Resource Table
+	ImageDirectoryEntryException                               // Exception Table
+	ImageDirectoryEntryCertificate                             // Certificate Directory
+	ImageDirectoryEntryBaseReloc                               // Base Relocation Table
+	ImageDirectoryEntryDebug                                   // Debug
+	ImageDirectoryEntryArchitecture                            // Architecture Specific Data
+	ImageDirectoryEntryGlobalPtr                               // The RVA of the value to be stored in the global pointer register.
+	ImageDirectoryEntryTLS                                     // The thread local storage (TLS) table
+	ImageDirectoryEntryLoadConfig                              // The load configuration table
+	ImageDirectoryEntryBoundImport                             // The bound import table
+	ImageDirectoryEntryIAT                                     // Import Address Table
+	ImageDirectoryEntryDelayImport                             // Delay Import Descriptor
+	ImageDirectoryEntryCLR                                     // CLR Runtime Header
+	ImageDirectoryEntryReserved                                // Must be zero
+	ImageNumberOfDirectoryEntries                              // Tables count.
 )
 
 // FileInfo represents the PE file information struct.

--- a/pe.go
+++ b/pe.go
@@ -176,25 +176,28 @@ const (
 
 )
 
+// ImageDirectoryEntry represents an entry inside the data directories.
+type ImageDirectoryEntry int
+
 // DataDirectory entries of an OptionalHeader
 const (
-	ImageDirectoryEntryExport       = 0  // Export Table
-	ImageDirectoryEntryImport       = 1  // Import Table
-	ImageDirectoryEntryResource     = 2  // Resource Table
-	ImageDirectoryEntryException    = 3  // Exception Table
-	ImageDirectoryEntryCertificate  = 4  // Certificate Directory
-	ImageDirectoryEntryBaseReloc    = 5  // Base Relocation Table
-	ImageDirectoryEntryDebug        = 6  // Debug
-	ImageDirectoryEntryArchitecture = 7  // Architecture Specific Data
-	ImageDirectoryEntryGlobalPtr    = 8  // The RVA of the value to be stored in the global pointer register.
-	ImageDirectoryEntryTLS          = 9  // The thread local storage (TLS) table
-	ImageDirectoryEntryLoadConfig   = 10 // The load configuration table
-	ImageDirectoryEntryBoundImport  = 11 // The bound import table
-	ImageDirectoryEntryIAT          = 12 // Import Address Table
-	ImageDirectoryEntryDelayImport  = 13 // Delay Import Descriptor
-	ImageDirectoryEntryCLR          = 14 // CLR Runtime Header
-	ImageDirectoryEntryReserved     = 15 // Must be zero
-	ImageNumberOfDirectoryEntries   = 16 // Tables count.
+	ImageDirectoryEntryExport       ImageDirectoryEntry = iota // Export Table
+	ImageDirectoryEntryImport                           = 1    // Import Table
+	ImageDirectoryEntryResource                         = 2    // Resource Table
+	ImageDirectoryEntryException                        = 3    // Exception Table
+	ImageDirectoryEntryCertificate                      = 4    // Certificate Directory
+	ImageDirectoryEntryBaseReloc                        = 5    // Base Relocation Table
+	ImageDirectoryEntryDebug                            = 6    // Debug
+	ImageDirectoryEntryArchitecture                     = 7    // Architecture Specific Data
+	ImageDirectoryEntryGlobalPtr                        = 8    // The RVA of the value to be stored in the global pointer register.
+	ImageDirectoryEntryTLS                              = 9    // The thread local storage (TLS) table
+	ImageDirectoryEntryLoadConfig                       = 10   // The load configuration table
+	ImageDirectoryEntryBoundImport                      = 11   // The bound import table
+	ImageDirectoryEntryIAT                              = 12   // Import Address Table
+	ImageDirectoryEntryDelayImport                      = 13   // Delay Import Descriptor
+	ImageDirectoryEntryCLR                              = 14   // CLR Runtime Header
+	ImageDirectoryEntryReserved                         = 15   // Must be zero
+	ImageNumberOfDirectoryEntries                       = 16   // Tables count.
 )
 
 // FileInfo represents the PE file information struct.


### PR DESCRIPTION
- Add humanize() for file size.
- Make `ImageDirectoryEntry` an alias for int.
- Implement ImageDirectoryEntry.String()
- Print DOS header, NT header