### PR TITLE
fix: use file.opt instead of opt when setting logger creating a file instance.

### DIFF
--- a/file.go
+++ b/file.go
@@ -176,7 +176,7 @@ func NewBytes(data []byte, opts *Options) (*File, error) {
 	}
 
 	var logger log.Logger
-	if opts.Logger == nil {
+	if file.opts.Logger == nil {
 		logger = log.NewStdLogger(os.Stdout)
 		file.logger = log.NewHelper(log.NewFilter(logger,
 			log.FilterLevel(log.LevelError)))

--- a/file.go
+++ b/file.go
@@ -144,12 +144,12 @@ func New(name string, opts *Options) (*File, error) {
 	}
 
 	var logger log.Logger
-	if opts.Logger == nil {
+	if file.opts.Logger == nil {
 		logger = log.NewStdLogger(os.Stdout)
 		file.logger = log.NewHelper(log.NewFilter(logger,
 			log.FilterLevel(log.LevelError)))
 	} else {
-		file.logger = log.NewHelper(opts.Logger)
+		file.logger = log.NewHelper(file.opts.Logger)
 	}
 
 	file.data = data


### PR DESCRIPTION
If pe.New function is called with nil as opts parameter, panic occurs due to comparing opts.logger(which opt is nil), so use file.opts instead.