### PR TITLE
chore(clr): Control CLR metadata parsing

### DIFF
--- a/dotnet.go
+++ b/dotnet.go
@@ -557,6 +557,10 @@ func (pe *File) parseCLRHeaderDirectory(rva, size uint32) error {
 	// other structures fails later.
 	pe.HasCLR = true
 
+	if pe.opts.OmitCLRMetadata {
+		return nil
+	}
+
 	offset = pe.GetOffsetFromRva(clrHeader.MetaData.VirtualAddress)
 	mh, err := pe.parseMetadataHeader(offset, clrHeader.MetaData.Size)
 	if err != nil {

--- a/file.go
+++ b/file.go
@@ -6,9 +6,9 @@ package pe
 
 import (
 	"errors"
+	"github.com/edsrzf/mmap-go"
 	"os"
 
-	"github.com/edsrzf/mmap-go"
 	"github.com/saferwall/pe/log"
 )
 
@@ -112,6 +112,9 @@ type Options struct {
 
 	// OmitCLRHeaderDirectory determines if CLR header directory parsing is skipped, by default (false).
 	OmitCLRHeaderDirectory bool
+
+	// OmitCLRMetadata determines if CLR metadata parsing is skipped, by default (false).
+	OmitCLRMetadata bool
 }
 
 // New instantiates a file instance with options given a file name.


### PR DESCRIPTION
A new option is provided to control whether
the CLR metadata is parsed. By default, CLR
metadata is parsed. Some users might not find
it useful, and parsing this data is a waste
of CPU cycles. Omitting CLR metadata can improve
PE parsing performance.