### PR TITLE
Fix dotnet coded index bugs

### DIFF
--- a/dotnet_helper.go
+++ b/dotnet_helper.go
@@ -22,14 +22,14 @@ var (
 	idxResolutionScope     = codedidx{tagbits: 2, idx: []int{Module, ModuleRef, AssemblyRef, TypeRef}}
 	idxMemberRefParent     = codedidx{tagbits: 3, idx: []int{TypeDef, TypeRef, ModuleRef, MethodDef, TypeSpec}}
 	idxHasConstant         = codedidx{tagbits: 2, idx: []int{Field, Param, Property}}
-	idxHasCustomAttributes = codedidx{tagbits: 5, idx: []int{Field, TypeRef, TypeDef, Param, InterfaceImpl, MemberRef, Module, Property, Event, StandAloneSig, ModuleRef, TypeSpec, Assembly, AssemblyRef, FileMD, ExportedType, ManifestResource}}
+	idxHasCustomAttributes = codedidx{tagbits: 5, idx: []int{MethodDef, Field, TypeRef, TypeDef, Param, InterfaceImpl, MemberRef, Module, DeclSecurity, Property, Event, StandAloneSig, ModuleRef, TypeSpec, Assembly, AssemblyRef, FileMD, ExportedType, ManifestResource, GenericParam, GenericParamConstraint, MethodSpec}}
 	idxCustomAttributeType = codedidx{tagbits: 3, idx: []int{MethodDef, MemberRef}}
 	idxHasFieldMarshall    = codedidx{tagbits: 1, idx: []int{Field, Param}}
 	idxHasDeclSecurity     = codedidx{tagbits: 2, idx: []int{TypeDef, MethodDef, Assembly}}
 	idxHasSemantics        = codedidx{tagbits: 1, idx: []int{Event, Property}}
 	idxMethodDefOrRef      = codedidx{tagbits: 1, idx: []int{MethodDef, MemberRef}}
 	idxMemberForwarded     = codedidx{tagbits: 1, idx: []int{Field, MethodDef}}
-	idxImplementation      = codedidx{tagbits: 2, idx: []int{AssemblyRef, ExportedType}}
+	idxImplementation      = codedidx{tagbits: 2, idx: []int{FileMD, AssemblyRef, ExportedType}}
 	idxTypeOrMethodDef     = codedidx{tagbits: 1, idx: []int{TypeDef, MethodDef}}
 
 	idxField        = codedidx{tagbits: 0, idx: []int{Field}}
@@ -68,7 +68,7 @@ func (pe *File) getCodedIndexSize(tagbits uint32, idx ...int) uint32 {
 			}
 		}
 	}
-	if maxColumnCount > maxIndex16 {
+	if maxColumnCount >= maxIndex16 {
 		return 4
 	}
 	return 2


### PR DESCRIPTION
Add missing tables to hasCustomAttribute and Implementation coded indexes and fix max column count comparsion according to spec

- hasCustomAttribute was missing MethodDef, DeclSecurity, GenericParam, GenericParamConstraint and MethodSpec tables in it's list, causing potential invalid index sizes
- Implementation was missing FileMD, causing potential invalid index sizes
- When calculating the index size, the maximum column count table was compared as "greater than" to max uint16. According to the spec, the index size should be 4 when they are equal aswell, so this should be fixed to greater or equal.

Spec references are attached.

![image](https://github.com/user-attachments/assets/af7a8a0b-4226-4303-8662-55ee8c3de999)
![image](https://github.com/user-attachments/assets/d12abf1e-6195-4551-95dd-c2875d3fbdf5)
![image](https://github.com/user-attachments/assets/0d2160cc-d9ee-40b6-a152-a45190170450)
