### PR TITLE
Support parsing file metadata table for dotnet

### DIFF
--- a/dotnet.go
+++ b/dotnet.go
@@ -728,6 +728,8 @@ func (pe *File) parseCLRHeaderDirectory(rva, size uint32) error {
 			table.Content, n, err = pe.parseMetadataMethodSpecTable(offset)
 		case GenericParamConstraint: // 0x2c
 			table.Content, n, err = pe.parseMetadataGenericParamConstraintTable(offset)
+		case FileMD: // 0x26
+			table.Content, n, err = pe.parseMetadataFileTable(offset)
 		default:
 			pe.logger.Warnf("unhandled metadata table %d %s offset 0x%x cols %d",
 				tableIndex, MetadataTableIndexToString(tableIndex), offset, table.CountCols)


### PR DESCRIPTION
Added support to FileMD table case.
In cases where FileMD was present, skipping this table was causing invalid parsing of the CLR, since this causes the next tables to be in the wrong offset.