### PR TITLE
fix: catch out-of-bounds access

### DIFF
--- a/version.go
+++ b/version.go
@@ -311,6 +311,9 @@ func (pe *File) ParseVersionResources() (map[string]string, error) {
 		if e.ID != VersionResourceType {
 			continue
 		}
+		if len(e.Directory.Entries) == 0 {
+			continue
+		}
 
 		directory := e.Directory.Entries[0].Directory
 


### PR DESCRIPTION
Version parsing relied on there being at least one entry per top-level directory. Verify this and discard empty ones for version information.