### PR TITLE
expose unmap

### DIFF
--- a/file.go
+++ b/file.go
@@ -6,8 +6,9 @@ package pe
 
 import (
 	"errors"
-	"github.com/edsrzf/mmap-go"
 	"os"
+
+	"github.com/edsrzf/mmap-go"
 
 	"github.com/saferwall/pe/log"
 )
@@ -196,15 +197,21 @@ func NewBytes(data []byte, opts *Options) (*File, error) {
 	return &file, nil
 }
 
-// Close closes the File.
 func (pe *File) Close() error {
-	if pe.data != nil {
-		_ = pe.data.Unmap()
-	}
+	_ = pe.Unmap()
 
 	if pe.f != nil {
 		return pe.f.Close()
 	}
+	return nil
+}
+
+// Close memory mapped file
+func (pe *File) Unmap() error {
+	if pe.data != nil {
+		return pe.data.Unmap()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Problem, I have an open file and I holding a lock so I can't reopen it.
I need to parse it with pe parser, Good I can use NewFile that accepts a file handle.
Ok, I completed the parsing, now I need to release resources allocated by pe.
Problem, if I call close, it will close my file handle and I lose the lock on the file.
Solution: expose unmap, so I can release the resources and still I can use my handle.