### PR TITLE
Fixing IsValidFunctionName() and IsPrintable() always returning true

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -144,7 +144,7 @@ func IsValidFunctionName(functionName string) bool {
 	numerals := "0123456789"
 	special := "_?@$()<>"
 	charset := alphabet + numerals + special
-	for _, c := range charset {
+	for _, c := range functionName {
 		if !strings.Contains(charset, string(c)) {
 			return false
 		}
@@ -159,7 +159,7 @@ func IsPrintable(s string) bool {
 	whitespace := " \t\n\r\v\f"
 	special := "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
 	charset := alphabet + numerals + special + whitespace
-	for _, c := range charset {
+	for _, c := range s {
 		if !strings.Contains(charset, string(c)) {
 			return false
 		}


### PR DESCRIPTION
IsValidFunctionName() and IsPrintable() were iterating over the allowed charset and comparing each char to the same charset which is always the case:

```go
for _, c := range charset {
		if !strings.Contains(charset, string(c)) { // never hit even for every functions name
			return false
		}
	}
```

It should iterate over the string in the argument:

```go
for _, c := range functionName { // iterating oveer the function name.
		if !strings.Contains(charset, string(c)) {
			return false
		}
	}
```