### PR TITLE
Update comment for OptionalHeader type

### DIFF
--- a/ntheader.go
+++ b/ntheader.go
@@ -33,7 +33,7 @@ type ImageNtHeader struct {
 	// executable files. It is represented with IMAGE_FILE_HEADER structure.
 	FileHeader ImageFileHeader `json:"file_header"`
 
-	// OptionalHeader is of type *OptionalHeader32 or *OptionalHeader64.
+	// OptionalHeader is of type ImageOptionalHeader32 or ImageOptionalHeader64.
 	OptionalHeader interface{} `json:"optional_header"`
 }
 


### PR DESCRIPTION
The docstring for `OptionalHeader` incorrectly stated its possible type states. Confirmed in lines 410,411 and the following test.
```go
fmt.Printf("%T\n", pe.NtHeader.OptionalHeader)
> pe.ImageOptionalHeader64
```