### PR TITLE
Suggestion: disabling style checks of staticcheck so the pipeline can fail on real errors.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,4 +50,5 @@ jobs:
           version: "2024.1"
           install-go: false
           cache-key: ${{ matrix.go }}
+          checks: '["all","-ST1*"]'
         if: matrix.os == 'windows-latest' && matrix.go-version == '1.23.x'


### PR DESCRIPTION
action pipelines seem to fail only because of staticcheck's style check which is inconvenient. I suggest to ignore the style checks. Sticking to that style is also another solution.