### PR TITLE
Fix (Out of memory bug) : Skip tables with unrealistic size 

### DIFF
--- a/dotnet.go
+++ b/dotnet.go
@@ -666,7 +666,7 @@ func (pe *File) parseCLRHeaderDirectory(rva, size uint32) error {
 		}
 
 		// Skip tables that have a unreasonable size
-		if uint64(table.CountCols) * uint64(binary.Size(ModuleTableRow{})) > uint64(len(pe.data)){
+		if uint64(table.CountCols) * 4 > uint64(len(pe.data)){
 			pe.logger.Warnf("Table %s has %d rows, which is not realistic considering PE file's size. Skipping it.", table.Name, table.CountCols)
             continue
 		}

--- a/dotnet.go
+++ b/dotnet.go
@@ -665,6 +665,12 @@ func (pe *File) parseCLRHeaderDirectory(rva, size uint32) error {
 			continue
 		}
 
+		// Skip tables that have a unreasonable size
+		if uint64(table.CountCols) * 2 > uint64(len(pe.data)){
+			pe.logger.Warnf("Table %s has %d rows, which is not realistic considering PE file's size. Skipping it.", table.Name, table.CountCols)
+            continue
+		}
+
 		n := uint32(0)
 		switch tableIndex {
 		case Module: // 0x00

--- a/dotnet.go
+++ b/dotnet.go
@@ -666,7 +666,7 @@ func (pe *File) parseCLRHeaderDirectory(rva, size uint32) error {
 		}
 
 		// Skip tables that have a unreasonable size
-		if uint64(table.CountCols) * 2 > uint64(len(pe.data)){
+		if uint64(table.CountCols) * uint64(binary.Size(ModuleTableRow{})) > uint64(len(pe.data)){
 			pe.logger.Warnf("Table %s has %d rows, which is not realistic considering PE file's size. Skipping it.", table.Name, table.CountCols)
             continue
 		}


### PR DESCRIPTION
inside `dotnet_metadata_tables.go`, the code reads allocates memory directly based on the row count.

````go
rowCount := int(pe.CLR.MetadataTables[Module].CountCols)
rows := make([]ModuleTableRow, rowCount)
````

This causes out of memory bug in some cases which breaks the parser.

I added a heuristic check inside `dotnet.go` to skip tables that could break the parser and continue parsing.
```go
if uint64(table.CountCols) * 4 > uint64(len(pe.data)){
             pe.logger.Warnf("Table %s has %d rows, which is not realistic considering PE file's size. Skipping it.", table.Name, table.CountCols)
             continue
}
```
